### PR TITLE
fix: correct loop iteration bug in p6_github_clone_parallel

### DIFF
--- a/gh-parallel
+++ b/gh-parallel
@@ -157,7 +157,7 @@ p6_github_clone_parallel() {
   shift 1
 
   local combo
-  for combo in echo "$@"; do
+  for combo in "$@"; do
     local repo
     repo=$(echo "$combo" | cut -d / -f 2)
     local dest_dir="$login_dir/$repo"


### PR DESCRIPTION
## Summary
- Fixes critical bug where the for loop iterated over literal string "echo" instead of arguments
- Changed `for combo in echo "$@"` to `for combo in "$@"`
- This bug caused incorrect behavior when processing multiple repositories in parallel

## Test plan
- [ ] Verify shellcheck passes
- [ ] Test `gh parallel clone <org> <dir>` with an organization containing multiple repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)