### PR TITLE
fix: add pipefail and dependency validation

### DIFF
--- a/gh-parallel
+++ b/gh-parallel
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # shellcheck shell=bash
+set -o pipefail
 
 ################################################################################
 #
@@ -51,11 +52,32 @@ EOF
 #
 #>
 ######################################################################
-p6main() {
-  shift 0
+p6_check_dependencies() {
+  if ! command -v parallel >/dev/null 2>&1; then
+    echo >&2 "error: GNU parallel is required but not installed"
+    echo >&2 "Install with: brew install parallel (macOS) or apt install parallel (Linux)"
+    exit 1
+  fi
 
+  if ! command -v gh >/dev/null 2>&1; then
+    echo >&2 "error: GitHub CLI (gh) is required but not installed"
+    echo >&2 "Install from: https://cli.github.com/"
+    exit 1
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo >&2 "error: GitHub CLI is not authenticated"
+    echo >&2 "Run: gh auth login"
+    exit 1
+  fi
+}
+
+p6main() {
   # sanitize env
   LC_ALL=C
+
+  # check required dependencies
+  p6_check_dependencies
 
   # parse options
   local flag


### PR DESCRIPTION
## Summary
- Add `set -o pipefail` for robust pipeline error handling
- Add p6_check_dependencies() to validate:
  - GNU parallel is installed
  - GitHub CLI (gh) is installed  
  - GitHub CLI is authenticated
- Provide helpful error messages with installation instructions
- Remove unnecessary `shift 0` in p6main

## Test plan
- [ ] Verify shellcheck passes
- [ ] Test without `parallel` installed - should show helpful error
- [ ] Test without `gh` installed - should show helpful error
- [ ] Test without `gh auth` - should show helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)