### PR TITLE
feat: add status command to show repository states

### DIFF
--- a/gh-parallel
+++ b/gh-parallel
@@ -35,8 +35,14 @@ p6_usage() {
 Usage:
   gh parallel -h
   gh parallel clone <login> <dest_dir> [-- <clone-options>]
+  gh parallel status <dest_dir>
+
+Commands:
+  clone   Clone all repositories for a user or organization
+  status  Show status of all repositories in a directory
 
 Options:
+  -h      Show this help message
 EOF
   exit "$rc"
 }
@@ -71,10 +77,11 @@ p6main() {
   local cmd="$1"
   shift 1
 
-  # security 101: only allow valid comamnds
+  # security 101: only allow valid commands
   case $cmd in
   help) p6_usage ;;
   clone) ;;
+  status) ;;
   *) p6_usage 1 "invalid cmd" ;;
   esac
 
@@ -139,6 +146,99 @@ p6_cmd_clone() {
 
   # shellcheck disable=SC2086
   parallel --bar --jobs 3 -m p6_github_clone_parallel "$login_dir" ::: $combos
+}
+
+######################################################################
+#<
+#
+# Function: p6_cmd_status(dir)
+#
+#  Args:
+#	  dir -
+#
+#>
+######################################################################
+p6_cmd_status() {
+  local dir="$1"
+
+  if [ $# -ne 1 ]; then
+    p6_usage 1 "status requires exactly one argument: <dest_dir>"
+  fi
+
+  if [ ! -d "$dir" ]; then
+    echo >&2 "error: directory does not exist: $dir"
+    exit 1
+  fi
+
+  local repos
+  repos=$(find "$dir" -mindepth 2 -maxdepth 2 -type d -name ".git" -exec dirname {} \; | sort)
+
+  if [ -z "$repos" ]; then
+    echo >&2 "error: no git repositories found in $dir"
+    exit 1
+  fi
+
+  local clean=0
+  local dirty=0
+  local behind=0
+  local ahead=0
+  local total=0
+
+  echo "Checking repository status..."
+  echo ""
+
+  local repo_dir
+  for repo_dir in $repos; do
+    total=$((total + 1))
+    local repo_name
+    repo_name=$(basename "$repo_dir")
+    local status_line=""
+
+    # Check for uncommitted changes
+    if ! (cd "$repo_dir" && git diff --quiet 2>/dev/null && git diff --cached --quiet 2>/dev/null); then
+      dirty=$((dirty + 1))
+      status_line="[dirty]  $repo_name"
+    else
+      # Check if behind/ahead of remote
+      local upstream
+      upstream=$(cd "$repo_dir" && git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null) || true
+      if [ -n "$upstream" ]; then
+        local counts
+        counts=$(cd "$repo_dir" && git rev-list --left-right --count HEAD..."$upstream" 2>/dev/null) || true
+        if [ -n "$counts" ]; then
+          local ahead_count behind_count
+          ahead_count=$(echo "$counts" | awk '{print $1}')
+          behind_count=$(echo "$counts" | awk '{print $2}')
+          if [ "$behind_count" -gt 0 ]; then
+            behind=$((behind + 1))
+            status_line="[behind] $repo_name ($behind_count commits)"
+          elif [ "$ahead_count" -gt 0 ]; then
+            ahead=$((ahead + 1))
+            status_line="[ahead]  $repo_name ($ahead_count commits)"
+          else
+            clean=$((clean + 1))
+            status_line="[clean]  $repo_name"
+          fi
+        else
+          clean=$((clean + 1))
+          status_line="[clean]  $repo_name"
+        fi
+      else
+        clean=$((clean + 1))
+        status_line="[clean]  $repo_name (no upstream)"
+      fi
+    fi
+
+    echo "$status_line"
+  done
+
+  echo ""
+  echo "Summary:"
+  echo "  Total:  $total"
+  echo "  Clean:  $clean"
+  echo "  Dirty:  $dirty"
+  echo "  Behind: $behind"
+  echo "  Ahead:  $ahead"
 }
 
 ######################################################################


### PR DESCRIPTION
## Summary
Add new `status` command to check the state of all repositories:
```bash
gh parallel status <dest_dir>
```

Shows each repository with one of these states:
- `[clean]`  - No uncommitted changes, up to date with remote
- `[dirty]`  - Has uncommitted changes
- `[behind]` - Behind remote (needs sync/pull)
- `[ahead]`  - Ahead of remote (needs push)

Displays summary counts at the end for quick overview.
Useful for understanding which repos need attention before syncing.

## Test plan
- [ ] Verify shellcheck passes
- [ ] Test `gh parallel status <dir>` shows status of repos
- [ ] Verify dirty repos are correctly identified
- [ ] Verify behind/ahead counts are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)