### PR TITLE
feat: add --jobs option for configurable parallelism

### DIFF
--- a/gh-parallel
+++ b/gh-parallel
@@ -34,9 +34,15 @@ p6_usage() {
   cat <<EOF
 Usage:
   gh parallel -h
-  gh parallel clone <login> <dest_dir> [-- <clone-options>]
+  gh parallel [-j <jobs>] [--dry-run] clone <login> <dest_dir>
 
-Options:
+Commands:
+  clone   Clone all repositories for a user or organization
+
+Global Options:
+  -h              Show this help message
+  -j, --jobs <n>  Number of parallel jobs (default: 3)
+  --dry-run       Show what would be done without executing
 EOF
   exit "$rc"
 }
@@ -51,27 +57,47 @@ EOF
 #
 #>
 ######################################################################
-p6main() {
-  shift 0
+P6_PARALLEL_JOBS=3
+P6_DRY_RUN=false
 
+p6main() {
   # sanitize env
   LC_ALL=C
 
-  # parse options
-  local flag
-  while getopts "h" flag; do
-    case $flag in
-    h) p6_usage 0 "help" ;;
-    *) p6_usage 1 "invalid flag" ;;
+  # parse global options
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -h | --help)
+      p6_usage 0 "help"
+      ;;
+    -j | --jobs)
+      P6_PARALLEL_JOBS="$2"
+      if ! [[ "$P6_PARALLEL_JOBS" =~ ^[0-9]+$ ]] || [ "$P6_PARALLEL_JOBS" -lt 1 ]; then
+        p6_usage 1 "invalid jobs value: $P6_PARALLEL_JOBS"
+      fi
+      shift 2
+      ;;
+    --dry-run)
+      P6_DRY_RUN=true
+      shift
+      ;;
+    -*)
+      p6_usage 1 "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
     esac
   done
-  shift $((OPTIND - 1))
 
   # grab command
-  local cmd="$1"
+  local cmd="${1:-}"
+  if [ -z "$cmd" ]; then
+    p6_usage 1 "command required"
+  fi
   shift 1
 
-  # security 101: only allow valid comamnds
+  # security 101: only allow valid commands
   case $cmd in
   help) p6_usage ;;
   clone) ;;
@@ -137,8 +163,18 @@ p6_cmd_clone() {
   local login_dir
   login_dir="$dir/$login"
 
+  local repo_count
+  repo_count=$(echo "$combos" | wc -l | tr -d ' ')
+  echo "Found $repo_count repositories"
+
+  if [ "$P6_DRY_RUN" = true ]; then
+    echo "[dry-run] Would clone $repo_count repositories with $P6_PARALLEL_JOBS parallel jobs:"
+    echo "$combos"
+    return 0
+  fi
+
   # shellcheck disable=SC2086
-  parallel --bar --jobs 3 -m p6_github_clone_parallel "$login_dir" ::: $combos
+  parallel --bar --jobs "$P6_PARALLEL_JOBS" -m p6_github_clone_parallel "$login_dir" ::: $combos
 }
 
 ######################################################################


### PR DESCRIPTION
## Summary
Add global options for controlling parallel execution:
```bash
gh parallel -j 8 clone myorg ./repos
gh parallel --jobs 8 clone myorg ./repos
gh parallel --dry-run clone myorg ./repos
```

Changes:
- Add `-j/--jobs` option to configure number of parallel jobs (default: 3)
- Add `--dry-run` option to preview what would be cloned
- Show repository count before cloning
- Replace getopts with manual option parsing for flexibility
- Validate jobs is a positive integer

The `--dry-run` mode is useful for:
- Verifying filters match expected repositories
- Understanding scope before large operations
- Testing commands without side effects

## Test plan
- [ ] Verify shellcheck passes
- [ ] Test `-j 8` increases parallelism
- [ ] Test `--dry-run` shows repos without cloning
- [ ] Test invalid jobs value shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)